### PR TITLE
Add groupid to recommended addition to plugins vector in leiningen

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Leiningen plugin to manage your checkouts without setting your hair on fire.
 
 ## Usage
 
-Put `[lein-checkout "0.4.2"]` into the `:plugins` vector of your
+Put `[org.clojars.timvisher/lein-checkout "0.4.2"]` into the `:plugins` vector of your
 `:user` profile, or if you are on Leiningen 1.x do `lein plugin install
 lein-checkout 0.4.2`.
 


### PR DESCRIPTION
Maybe my setup is unique, but I needed to do this to get it to work when I added it to the plugins vector of my profiles.clj.